### PR TITLE
Create gcp and ga helper packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,27 +3,31 @@
 This repository contains small helper packages used in personal projects. Below is a high level description of each source file so that a GenAI agent can understand how they fit together.
 
 ## Root package (`common`)
-- **appengine.go** – extracts the App Engine version from the request context and stores it in the `VERSION` variable defined in `common.go`.
-- **bigquery.go** – helpers to authenticate with BigQuery, create datasets/tables and stream rows.
 - **common.go** – declares shared variables such as `ISDEBUG` and `VERSION`.
 - **convert.go** – miscellaneous conversion utilities (string/number conversions, rounding, camel case, etc.).
 - **convert_test.go** – tests for `CamelCase` from `convert.go`.
 - **cookie.go** – visitor cookie helpers (create, read, clear) and `Visitor` struct.
 - **cookie_test.go** – tests cookie creation and attributes.
 - **crypt.go** – MD5 and CRC32 helpers plus AES based `Encrypt`/`Decrypt` functions.
-- **datastore.go** – helper to fetch the first datastore entity in a query.
 - **debug.go** – utilities for dumping HTTP requests, responses and cookies for debugging.
 - **file.go** – reads file contents.
-- **ga.go** – Google Analytics tracking helpers and structures for events.
 - **interfaces.go** – generic routines to marshal/unmarshal JSON/XML and manage HTTP bodies.
 - **logging.go** – simple Debug/Info/Error logging that respects `ISDEBUG`.
-- **memcache.go** – wrappers for App Engine memcache operations on bytes and objects.
 - **slice.go** – slice helper routines like `AddIfNotExists`.
 - **url.go** – validation helper for HTTP/HTTPS URLs.
 - **url_test.go** – tests for `url.go`.
+- **web.go** – assorted web utilities: service account HTTP client, spam/bot detection, and helper HTML template rendering.
+
+## `gcp` package
+- **appengine.go** – extracts the App Engine version and sets the `VERSION` variable.
+- **bigquery.go** – helpers to authenticate with BigQuery, create datasets/tables and stream rows.
+- **datastore.go** – helper to fetch the first datastore entity in a query.
+- **memcache.go** – wrappers for App Engine memcache operations on bytes and objects.
 - **user.go** – datastore storage of users and roles.
 - **user_test.go** – tests `EnsureUserExists` and `GetUserRole`.
-- **web.go** – assorted web utilities: service account HTTP client, spam/bot detection, and helper HTML template rendering.
+
+## `ga` package
+- **ga.go** – Google Analytics tracking helpers and structures for events.
 
 These files depend on each other via the exported helpers. For example `web.go` uses `memcache`, `logging` and `convert`; BigQuery functions log via `logging.go` and use utilities from `crypt.go` and `convert.go`.
 

--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ Import subpackages, for example:
 ```go
 import "github.com/patdeg/common/auth"
 ```
+You can also import specialized helpers:
+```go
+import "github.com/patdeg/common/gcp"
+import "github.com/patdeg/common/ga"
+```

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/patdeg/common"
+	"github.com/patdeg/common/gcp"
 	"github.com/patdeg/common/track"
 
 	"golang.org/x/net/context"
@@ -112,10 +113,10 @@ func GoogleCallbackHandler(w http.ResponseWriter, r *http.Request) {
 	if adminEmails[email] {
 		role = "admin"
 	}
-	if _, err := common.EnsureUserExists(ctx, email, role); err != nil {
+	if _, err := gcp.EnsureUserExists(ctx, email, role); err != nil {
 		common.Error("EnsureUserExists: %v", err)
 	}
-	storedRole, err := common.GetUserRole(ctx, email)
+	storedRole, err := gcp.GetUserRole(ctx, email)
 	if err != nil {
 		common.Error("GetUserRole: %v", err)
 		http.Redirect(w, r, "/", http.StatusFound)

--- a/ga/ga.go
+++ b/ga/ga.go
@@ -1,4 +1,5 @@
-package common
+// Package ga provides Google Analytics helpers.
+package ga
 
 import (
 	"bytes"

--- a/gcp/appengine.go
+++ b/gcp/appengine.go
@@ -1,4 +1,4 @@
-package common
+package gcp
 
 import (
 	"strings"

--- a/gcp/bigquery.go
+++ b/gcp/bigquery.go
@@ -1,5 +1,5 @@
-// Package common provides shared helpers used across the mygoto.me service.
-package common
+// Package gcp provides Google Cloud helpers for mygoto.me service.
+package gcp
 
 import (
 	"errors"

--- a/gcp/datastore.go
+++ b/gcp/datastore.go
@@ -1,4 +1,4 @@
-package common
+package gcp
 
 import (
 	"golang.org/x/net/context"

--- a/gcp/memcache.go
+++ b/gcp/memcache.go
@@ -1,4 +1,4 @@
-package common
+package gcp
 
 import (
 	"time"

--- a/gcp/user.go
+++ b/gcp/user.go
@@ -1,4 +1,4 @@
-package common
+package gcp
 
 import (
 	"time"

--- a/gcp/user_test.go
+++ b/gcp/user_test.go
@@ -1,4 +1,4 @@
-package common
+package gcp
 
 import (
 	"testing"

--- a/track/adwords.go
+++ b/track/adwords.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/patdeg/common"
+	"github.com/patdeg/common/gcp"
 
 	"github.com/mssola/user_agent"
 	"golang.org/x/net/context"
@@ -74,7 +75,7 @@ func createClicksTableInBigQuery(c context.Context, d string) error {
 
 	common.Info("Create a new daily clicks table in BigQuery")
 
-	if err := common.CreateDatasetIfNotExists(c, adwordsProjectID, adwordsDataset); err != nil {
+	if err := gcp.CreateDatasetIfNotExists(c, adwordsProjectID, adwordsDataset); err != nil {
 		common.Error("Error ensuring dataset %s: %v", adwordsDataset, err)
 		return err
 	}
@@ -144,7 +145,7 @@ func createClicksTableInBigQuery(c context.Context, d string) error {
 		},
 	}
 
-	return common.CreateTableInBigQuery(c, newTable)
+	return gcp.CreateTableInBigQuery(c, newTable)
 }
 
 // CreateTodayClicksTableInBigQueryHandler sets up today's clicks table in

--- a/track/bigquery_helpers.go
+++ b/track/bigquery_helpers.go
@@ -2,6 +2,7 @@ package track
 
 import (
 	"github.com/patdeg/common"
+	"github.com/patdeg/common/gcp"
 
 	"golang.org/x/net/context"
 	bigquery "google.golang.org/api/bigquery/v2"
@@ -11,7 +12,7 @@ import (
 // insertWithTableCreation streams data to BigQuery and creates the table if it doesn't exist.
 func insertWithTableCreation(c context.Context, projectID, datasetID, tableID string, req *bigquery.TableDataInsertAllRequest, createTable func(context.Context, string) error) error {
 	common.Debug("insertWithTableCreation dataset=%s table=%s", datasetID, tableID)
-	err := common.StreamDataInBigquery(c, projectID, datasetID, tableID, req)
+	err := gcp.StreamDataInBigquery(c, projectID, datasetID, tableID, req)
 	if err != nil {
 		common.Error("Error while streaming data to BigQuery: %v", err)
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
@@ -21,7 +22,7 @@ func insertWithTableCreation(c context.Context, projectID, datasetID, tableID st
 				common.Error("Error creating table %s: %v", tableID, err2)
 				return err2
 			}
-			if err3 := common.StreamDataInBigquery(c, projectID, datasetID, tableID, req); err3 != nil {
+			if err3 := gcp.StreamDataInBigquery(c, projectID, datasetID, tableID, req); err3 != nil {
 				common.Error("Error streaming to BigQuery after creating table: %v", err3)
 				return err3
 			}

--- a/track/bigquery_tables.go
+++ b/track/bigquery_tables.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/patdeg/common"
+	"github.com/patdeg/common/gcp"
 
 	"golang.org/x/net/context"
 	bigquery "google.golang.org/api/bigquery/v2"
@@ -12,7 +13,7 @@ import (
 func createVisitsTableInBigQuery(c context.Context, d string) error {
 	common.Info(">>>> createVisitsTableInBigQuery")
 
-	if err := common.CreateDatasetIfNotExists(c, bqProjectID, visitsDataset); err != nil {
+	if err := gcp.CreateDatasetIfNotExists(c, bqProjectID, visitsDataset); err != nil {
 		common.Error("Error ensuring dataset %s: %v", visitsDataset, err)
 		return err
 	}
@@ -59,13 +60,13 @@ func createVisitsTableInBigQuery(c context.Context, d string) error {
 			},
 		},
 	}
-	return common.CreateTableInBigQuery(c, newTable)
+	return gcp.CreateTableInBigQuery(c, newTable)
 }
 
 func createEventsTableInBigQuery(c context.Context, d string) error {
 	common.Info(">>>> createEventsTableInBigQuery")
 
-	if err := common.CreateDatasetIfNotExists(c, bqProjectID, eventsDataset); err != nil {
+	if err := gcp.CreateDatasetIfNotExists(c, bqProjectID, eventsDataset); err != nil {
 		common.Error("Error ensuring dataset %s: %v", eventsDataset, err)
 		return err
 	}
@@ -116,5 +117,5 @@ func createEventsTableInBigQuery(c context.Context, d string) error {
 			},
 		},
 	}
-	return common.CreateTableInBigQuery(c, newTable)
+	return gcp.CreateTableInBigQuery(c, newTable)
 }

--- a/web.go
+++ b/web.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/mssola/user_agent"
+	"github.com/patdeg/common/gcp"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -144,57 +145,57 @@ func IsHacker(r *http.Request) bool {
 
 	c := r.Context()
 
-	if GetMemCacheString(c, "hacker-"+r.RemoteAddr) != "" {
+	if gcp.GetMemCacheString(c, "hacker-"+r.RemoteAddr) != "" {
 		Info("IsHacker: Repeat IP %v", r.RemoteAddr)
 		return true
 	}
 
 	if IsSpam(c, r.Referer()) {
 		Info("IsHacker: Is Spam")
-		SetMemCacheString(c, "hacker-"+r.RemoteAddr, "1", 4)
+		gcp.SetMemCacheString(c, "hacker-"+r.RemoteAddr, "1", 4)
 		return true
 	}
 
 	if r.UserAgent() == "" {
 		Info("IsHacker: UserAgent empty")
-		SetMemCacheString(c, "hacker-"+r.RemoteAddr, "1", 4)
+		gcp.SetMemCacheString(c, "hacker-"+r.RemoteAddr, "1", 4)
 		return true
 	}
 
 	if strings.Contains(r.URL.Path, ".php") {
 		Info("IsHacker: Requesting .php page, rejecting: %v", r.URL.Path)
-		SetMemCacheString(c, "hacker-"+r.RemoteAddr, "1", 4)
+		gcp.SetMemCacheString(c, "hacker-"+r.RemoteAddr, "1", 4)
 		return true
 	}
 
 	if strings.HasPrefix(r.URL.Path, "/wp/") {
 		Info("IsHacker: WordPress path: %v", r.URL.Path)
-		SetMemCacheString(c, "hacker-"+r.RemoteAddr, "1", 4)
+		gcp.SetMemCacheString(c, "hacker-"+r.RemoteAddr, "1", 4)
 		return true
 	}
 
 	if strings.HasPrefix(r.URL.Path, "/wp-content/") {
 		Info("IsHacker: WordPress path: %v", r.URL.Path)
-		SetMemCacheString(c, "hacker-"+r.RemoteAddr, "1", 4)
+		gcp.SetMemCacheString(c, "hacker-"+r.RemoteAddr, "1", 4)
 		return true
 	}
 
 	if strings.HasPrefix(r.URL.Path, "/blog/") {
 		Info("IsHacker: Blog path: %v", r.URL.Path)
-		SetMemCacheString(c, "hacker-"+r.RemoteAddr, "1", 4)
+		gcp.SetMemCacheString(c, "hacker-"+r.RemoteAddr, "1", 4)
 		return true
 	}
 
 	if strings.HasPrefix(r.URL.Path, "/wordpress/") {
 		Info("IsHacker: WordPress path: %v", r.URL.Path)
-		SetMemCacheString(c, "hacker-"+r.RemoteAddr, "1", 4)
+		gcp.SetMemCacheString(c, "hacker-"+r.RemoteAddr, "1", 4)
 		return true
 	}
 
 	if r.Header.Get("X-AppEngine-Country") == "UA" {
 		if (r.Header.Get("X-AppEngine-City") == "lviv") || (r.Header.Get("X-AppEngine-City") == "kyiv") {
 			Info("IsHacker: Ukraine traffic - City : %v", r.Header.Get("X-AppEngine-City"))
-			SetMemCacheString(c, "hacker-"+r.RemoteAddr, "1", 4)
+			gcp.SetMemCacheString(c, "hacker-"+r.RemoteAddr, "1", 4)
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
- group Google Cloud helpers under `gcp`
- move Google Analytics code to new `ga` package
- update imports for the new structure
- document new packages in README and AGENTS

## Testing
- `go test ./...` *(fails: Forbidden)*
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68426baaf9c08325bffd224930bd655b