### PR TITLE
Improve GetContent with io.ReadAll and new tests

### DIFF
--- a/file.go
+++ b/file.go
@@ -7,22 +7,23 @@ import (
 	"golang.org/x/net/context"
 )
 
+// GetContent reads the file named by filename and returns its contents.
+// Any errors encountered are logged and returned.
 func GetContent(c context.Context, filename string) (*[]byte, error) {
-	file, err := os.OpenFile(filename, os.O_RDONLY, 0666)
+	file, err := os.Open(filename)
 	if err != nil {
-		Error("Error opening file: %v", err)
+		Error("Error opening file %s: %v", filename, err)
 		return nil, err
 	}
 	defer file.Close()
+
 	Info("FILE FOUND : %s", filename)
-	buffer := make([]byte, 10*1024*1024)
-	n, err := file.Read(buffer)
-	if (err == nil) || (err == io.EOF) {
-		content := buffer[:n]
-		return &content, nil
+	content, err := io.ReadAll(file)
+	if err != nil {
+		Error("Error reading file %s: %v", filename, err)
+		return nil, err
 	}
 
-	Error("Error reading file: %v", err)
-	return nil, err
+	return &content, nil
 
 }

--- a/file_test.go
+++ b/file_test.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+)
+
+func TestGetContentSmallFile(t *testing.T) {
+	f, err := os.CreateTemp("", "small")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString("hello"); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	b, err := GetContent(context.Background(), f.Name())
+	if err != nil {
+		t.Fatalf("GetContent returned error: %v", err)
+	}
+	if string(*b) != "hello" {
+		t.Errorf("got %q want %q", string(*b), "hello")
+	}
+}
+
+func TestGetContentLargeFile(t *testing.T) {
+	f, err := os.CreateTemp("", "large")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	data := bytes.Repeat([]byte("a"), 12*1024*1024)
+	if _, err := f.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	b, err := GetContent(context.Background(), f.Name())
+	if err != nil {
+		t.Fatalf("GetContent returned error: %v", err)
+	}
+	if len(*b) != len(data) {
+		t.Errorf("len=%d want %d", len(*b), len(data))
+	}
+}


### PR DESCRIPTION
## Summary
- document GetContent
- use `io.ReadAll` to support large files and log errors
- add small and large file tests for GetContent

## Testing
- `go test ./...` *(fails: forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_684273007a608325b6bc15044317d4dd