### PR TITLE
Improve cookie tests and docs

### DIFF
--- a/convert_test.go
+++ b/convert_test.go
@@ -1,6 +1,10 @@
+// Package common contains tests for conversion helpers.
 package common
 
 import "testing"
+
+// TestCamelCase verifies that CamelCase converts dash separated strings into
+// camel cased words.
 
 func TestCamelCase(t *testing.T) {
 	got := CamelCase("hello-world")

--- a/cookie.go
+++ b/cookie.go
@@ -51,6 +51,13 @@ func DoesCookieExists(r *http.Request) bool {
 }
 
 // GetCookieID retrieves the visitor ID cookie or creates a new one if missing.
+//
+// The created cookie is secured with the following attributes:
+//   - Path is always set to "/" so the ID is sent for all application routes.
+//   - Expires is 30 days in the future, giving the cookie a one month lifetime.
+//   - HttpOnly and Secure are true to prevent JavaScript access and require HTTPS.
+//   - SameSite is Lax to protect against CSRF while allowing normal navigation.
+//   - Domain is only set when the host is neither localhost nor 127.0.0.1.
 func GetCookieID(w http.ResponseWriter, r *http.Request) string {
 	Debug(">>>> GetCookieID")
 

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -1,12 +1,16 @@
+// Package common contains tests for cookie helpers.
 package common
 
 import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
-func TestGetCookieIDAttributes(t *testing.T) {
+// TestGetCookieIDProductionHost verifies that GetCookieID sets the expected
+// security attributes and domain when running on a production host.
+func TestGetCookieIDProductionHost(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "http://example.com/", nil)
 	r.Host = "example.com:8080"
@@ -32,7 +36,62 @@ func TestGetCookieIDAttributes(t *testing.T) {
 	if !c.Secure {
 		t.Error("Secure not set")
 	}
+	if c.Path != "/" {
+		t.Errorf("Path = %q, want /", c.Path)
+	}
+	if !c.Expires.After(time.Now().Add(29*24*time.Hour)) ||
+		!c.Expires.Before(time.Now().Add(31*24*time.Hour)) {
+		t.Errorf("Expires = %v, want about 30 days", c.Expires)
+	}
 	if c.Domain != "example.com" {
 		t.Errorf("Domain = %q, want example.com", c.Domain)
+	}
+}
+
+// TestGetCookieIDLocalhost verifies that the domain attribute is omitted when
+// running on localhost.
+func TestGetCookieIDLocalhost(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "http://localhost/", nil)
+	r.Host = "localhost:8080"
+	_ = GetCookieID(w, r)
+	res := w.Result()
+	defer res.Body.Close()
+	var c *http.Cookie
+	for _, cookie := range res.Cookies() {
+		if cookie.Name == "ID" {
+			c = cookie
+			break
+		}
+	}
+	if c == nil {
+		t.Fatal("Set-Cookie header not found")
+	}
+	if c.Domain != "" {
+		t.Errorf("Domain = %q, want empty", c.Domain)
+	}
+}
+
+// TestGetCookieIDLocalIP verifies that the domain attribute is omitted when the
+// host is an IP address on localhost.
+func TestGetCookieIDLocalIP(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "http://127.0.0.1/", nil)
+	r.Host = "127.0.0.1:8080"
+	_ = GetCookieID(w, r)
+	res := w.Result()
+	defer res.Body.Close()
+	var c *http.Cookie
+	for _, cookie := range res.Cookies() {
+		if cookie.Name == "ID" {
+			c = cookie
+			break
+		}
+	}
+	if c == nil {
+		t.Fatal("Set-Cookie header not found")
+	}
+	if c.Domain != "" {
+		t.Errorf("Domain = %q, want empty", c.Domain)
 	}
 }

--- a/url_test.go
+++ b/url_test.go
@@ -1,6 +1,10 @@
+// Package common contains tests for URL helpers.
 package common
 
 import "testing"
+
+// TestIsValidHTTPURL checks that IsValidHTTPURL accepts HTTP/HTTPS URLs and
+// rejects other schemes or malformed strings.
 
 func TestIsValidHTTPURL(t *testing.T) {
 	valid := []string{


### PR DESCRIPTION
## Summary
- document cookie security attributes
- document test packages
- improve cookie tests covering domain, path and expiration
- add descriptive comments for all tests

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684272fe3a4483259ed4e819ae44d7f0