### PR TITLE
Improve example documentation

### DIFF
--- a/examples/appengine/README.md
+++ b/examples/appengine/README.md
@@ -1,0 +1,19 @@
+This example demonstrates using the `auth` subpackage to require Google OAuth
+login before serving a simple page.
+
+Handlers
+--------
+
+- `/` handled by `HelloHandler` which greets authenticated users.
+- `/goog_login` begins the OAuth flow using `auth.GoogleLoginHandler`.
+- `/goog_callback` finishes the OAuth flow via `auth.GoogleCallbackHandler`.
+
+Environment variables
+---------------------
+
+- `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` – credentials for a
+  Google OAuth client.
+- `ADMIN_EMAILS` – optional comma-separated list of admin emails.
+- `PORT` – HTTP port to listen on (default `8080`).
+
+Run `go run main.go` from this directory after setting the variables above.

--- a/examples/appengine/main.go
+++ b/examples/appengine/main.go
@@ -1,3 +1,14 @@
+// Package main provides a minimal example server showing how to use the
+// authentication helpers from the common repository. It defines a simple
+// greeting handler and wires up the OAuth login and callback handlers from the
+// auth subpackage.
+//
+// Environment variables:
+//   - GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET must be set with
+//     credentials for a Google OAuth web client.
+//   - ADMIN_EMAILS optionally provides a comma separated list of admin
+//     accounts allowed to log in.
+//   - PORT specifies the HTTP port for the server (default 8080).
 package main
 
 import (
@@ -10,7 +21,8 @@ import (
 	"github.com/patdeg/common/auth"
 )
 
-// HelloHandler greets authenticated users.
+// HelloHandler responds with a greeting to authenticated users. If the user is
+// not logged in, they are redirected to the Google OAuth login flow.
 func HelloHandler(w http.ResponseWriter, r *http.Request) {
 	if auth.RedirectIfNotLoggedIn(w, r) {
 		return
@@ -20,10 +32,19 @@ func HelloHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	// The root path requires login and displays a greeting.
 	http.HandleFunc("/", HelloHandler)
+
+	// GoogleLoginHandler initiates the OAuth flow by redirecting the user
+	// to Google's consent page.
 	http.HandleFunc("/goog_login", auth.GoogleLoginHandler)
+
+	// GoogleCallbackHandler completes the OAuth flow and sets the login
+	// cookie before redirecting back to the requested page.
 	http.HandleFunc("/goog_callback", auth.GoogleCallbackHandler)
 
+	// The HTTP server listens on the port specified by the PORT environment
+	// variable. It defaults to 8080 when unset.
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"


### PR DESCRIPTION
## Summary
- clarify purpose of appengine example and add env vars
- explain handlers and port configuration

## Testing
- `go test ./...` *(fails: module download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68427312ea148325a0f3b29fc1dd8749