### PR TITLE
Enhance OAuth flow security

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,9 +1,19 @@
+// Package auth implements a minimal Google OAuth workflow used by the
+// other packages in this repository. Users are redirected to Google for
+// authentication and, on success, returned to /goog_callback where their
+// email address is stored in a secure cookie. The optional "redirect"
+// parameter is preserved as the OAuth state value so that users can be
+// returned to the page they originally attempted to visit.
+//
+// To avoid open redirect vulnerabilities the state value is validated to
+// ensure it is a relative path on the current site.
 package auth
 
 import (
 	"encoding/json"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -39,21 +49,53 @@ func init() {
 	}
 }
 
+// sanitizeRedirect ensures the given value is a relative URL path. Any
+// absolute URL or path not starting with "/" results in the fallback "/".
+// The returned string may include query parameters.
+func sanitizeRedirect(raw string) string {
+	if raw == "" {
+		return "/"
+	}
+	if strings.HasPrefix(raw, "//") {
+		return "/"
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "/"
+	}
+	if u.IsAbs() || u.Host != "" || u.Scheme != "" {
+		return "/"
+	}
+	if !strings.HasPrefix(u.Path, "/") {
+		return "/"
+	}
+	return u.String()
+}
+
+// googleOAuthConfig returns an oauth2.Config with the RedirectURL set for the
+// current request host. The redirect points to /goog_callback where the
+// authorization code is exchanged.
 func googleOAuthConfig(r *http.Request) *oauth2.Config {
 	conf := *googleConfig
 	conf.RedirectURL = "https://" + r.Host + "/goog_callback"
 	return &conf
 }
 
+// RedirectIfNotLoggedIn checks for the login cookie and, if missing, initiates
+// the OAuth login flow. The current path is used as the state value so users
+// return to their original destination after logging in.
 func RedirectIfNotLoggedIn(w http.ResponseWriter, r *http.Request) bool {
 	if _, err := r.Cookie("organizer_email"); err != nil {
-		url := googleOAuthConfig(r).AuthCodeURL(r.URL.Path)
+		url := googleOAuthConfig(r).AuthCodeURL(sanitizeRedirect(r.URL.Path))
 		http.Redirect(w, r, url, http.StatusFound)
 		return true
 	}
 	return false
 }
 
+// RedirectIfNotLoggedInAPI behaves like RedirectIfNotLoggedIn but returns a
+// 401 status instead of redirecting. It is intended for API endpoints that
+// require authentication.
 func RedirectIfNotLoggedInAPI(w http.ResponseWriter, r *http.Request) bool {
 	if _, err := r.Cookie("organizer_email"); err != nil {
 		http.Error(w, "Login required", http.StatusUnauthorized)
@@ -62,20 +104,24 @@ func RedirectIfNotLoggedInAPI(w http.ResponseWriter, r *http.Request) bool {
 	return false
 }
 
+// GoogleLoginHandler starts the OAuth login process. The optional "redirect"
+// parameter is validated and stored as the OAuth state to protect against open
+// redirects. A login event is also recorded for analytics.
 func GoogleLoginHandler(w http.ResponseWriter, r *http.Request) {
-	state := r.FormValue("redirect")
-	if state == "" {
-		state = "/"
-	}
+	state := sanitizeRedirect(r.FormValue("redirect"))
 	url := googleOAuthConfig(r).AuthCodeURL(state)
 	track.TrackEventDetails(w, r, common.GetCookieID(w, r), "Google Login", state, "", 0)
 	http.Redirect(w, r, url, http.StatusFound)
 }
 
+// GoogleCallbackHandler handles the OAuth callback from Google. It exchanges
+// the authorization code for a token, records the user email in a secure
+// cookie and redirects the user back to the sanitized state value. If the
+// state is empty or invalid a default dashboard or admin page is used.
 func GoogleCallbackHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	code := r.FormValue("code")
-	state := r.FormValue("state")
+	state := sanitizeRedirect(r.FormValue("state"))
 	conf := googleOAuthConfig(r)
 	tok, err := conf.Exchange(ctx, code)
 	if err != nil {
@@ -133,6 +179,9 @@ func GoogleCallbackHandler(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, redirect, http.StatusFound)
 }
 
+// googleUserEmail fetches the authenticated user's email address using the
+// provided OAuth access token. An empty string is returned if the request fails
+// or the response cannot be decoded.
 func googleUserEmail(c context.Context, token string) (string, error) {
 	client := urlfetch.Client(c)
 	resp, err := client.Get("https://www.googleapis.com/oauth2/v2/userinfo?access_token=" + token)

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1,0 +1,45 @@
+package auth
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeRedirect(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", "/"},
+		{"/dashboard", "/dashboard"},
+		{"http://evil.com", "/"},
+		{"//evil", "/"},
+		{"/path?x=1", "/path?x=1"},
+	}
+	for _, c := range cases {
+		if got := sanitizeRedirect(c.in); got != c.want {
+			t.Errorf("sanitizeRedirect(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestGoogleLoginHandlerUnsafeRedirect(t *testing.T) {
+	r := httptest.NewRequest("GET", "https://example.com/login?redirect=http://evil.com", nil)
+	r.Host = "example.com"
+	w := httptest.NewRecorder()
+	GoogleLoginHandler(w, r)
+	res := w.Result()
+	loc := res.Header.Get("Location")
+	if loc == "" {
+		t.Fatal("no redirect")
+	}
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("invalid redirect URL: %v", err)
+	}
+	if !strings.Contains(u.RawQuery, "state=%2F") {
+		t.Errorf("state not sanitized in redirect: %s", loc)
+	}
+}


### PR DESCRIPTION
## Summary
- document OAuth login process in `auth` package
- sanitize redirect state to allow only relative paths
- clarify security considerations in handlers
- add tests rejecting unsafe redirect targets

## Testing
- `go test ./...` *(fails: google.golang.org/api download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684273122d9c8325b1333e1b1886933a