### PR TITLE
Add BigQuery store documentation and tests

### DIFF
--- a/track/bigquery_store.go
+++ b/track/bigquery_store.go
@@ -1,5 +1,10 @@
 package track
 
+// This file contains helpers to persist Visit and Event records in BigQuery.
+// Both types are stored in daily tables created on demand. The data is
+// streamed using bigquery.TableDataInsertAllRequest built from a Visit
+// structure.
+
 import (
 	"strconv"
 	"time"
@@ -10,48 +15,69 @@ import (
 	bigquery "google.golang.org/api/bigquery/v2"
 )
 
-func StoreVisitInBigQuery(c context.Context, v *Visit) error {
-	common.Info(">>>> StoreVisitInBigQuery")
-	common.Debug("Dataset=%s", visitsDataset)
-
-	insertId := strconv.FormatInt(time.Now().UnixNano(), 10) + "-" + v.Cookie
-
-	req := &bigquery.TableDataInsertAllRequest{
+// visitInsertRequest builds the BigQuery request used by StoreVisitInBigQuery.
+// The insertId combines the current timestamp in nanoseconds with the visitor
+// cookie to ensure uniqueness and allow de-duplication on retries.
+// Each Visit field is mapped directly to a column in BigQuery.
+func visitInsertRequest(v *Visit, now time.Time) *bigquery.TableDataInsertAllRequest {
+	insertId := strconv.FormatInt(now.UnixNano(), 10) + "-" + v.Cookie
+	return &bigquery.TableDataInsertAllRequest{
 		Kind: "bigquery#tableDataInsertAllRequest",
 		Rows: []*bigquery.TableDataInsertAllRequestRows{
 			{
 				InsertId: insertId,
 				Json: map[string]bigquery.JsonValue{
-					"Cookie":         v.Cookie,
-					"Session":        v.Session,
-					"URI":            v.URI,
-					"Referer":        v.Referer,
-					"Time":           v.Time,
-					"Host":           v.Host,
-					"RemoteAddr":     v.RemoteAddr,
-					"InstanceId":     v.InstanceId,
-					"VersionId":      v.VersionId,
-					"Scheme":         v.Scheme,
-					"Country":        v.Country,
-					"Region":         v.Region,
-					"City":           v.City,
-					"Lat":            v.Lat,
-					"Lon":            v.Lon,
-					"AcceptLanguage": v.AcceptLanguage,
-					"UserAgent":      v.UserAgent,
-					"IsMobile":       v.IsMobile,
-					"IsBot":          v.IsBot,
-					"MozillaVersion": v.MozillaVersion,
-					"Platform":       v.Platform,
-					"OS":             v.OS,
-					"EngineName":     v.EngineName,
-					"EngineVersion":  v.EngineVersion,
-					"BrowserName":    v.BrowserName,
-					"BrowserVersion": v.BrowserVersion,
+					"Cookie":         v.Cookie,         // visitor cookie ID
+					"Session":        v.Session,        // session ID cached in memcache
+					"URI":            v.URI,            // request URI
+					"Referer":        v.Referer,        // HTTP referer
+					"Time":           v.Time,           // time of the visit
+					"Host":           v.Host,           // request host
+					"RemoteAddr":     v.RemoteAddr,     // remote address
+					"InstanceId":     v.InstanceId,     // App Engine instance ID
+					"VersionId":      v.VersionId,      // deployed version ID
+					"Scheme":         v.Scheme,         // http or https
+					"Country":        v.Country,        // geo country
+					"Region":         v.Region,         // geo region
+					"City":           v.City,           // geo city
+					"Lat":            v.Lat,            // geo latitude
+					"Lon":            v.Lon,            // geo longitude
+					"AcceptLanguage": v.AcceptLanguage, // browser Accept-Language header
+					"UserAgent":      v.UserAgent,      // raw User-Agent string
+					"IsMobile":       v.IsMobile,       // true for mobile browsers
+					"IsBot":          v.IsBot,          // true if the UA is a bot
+					"MozillaVersion": v.MozillaVersion, // UA Mozilla version
+					"Platform":       v.Platform,       // UA reported platform
+					"OS":             v.OS,             // UA reported OS
+					"EngineName":     v.EngineName,     // rendering engine name
+					"EngineVersion":  v.EngineVersion,  // rendering engine version
+					"BrowserName":    v.BrowserName,    // browser name
+					"BrowserVersion": v.BrowserVersion, // browser version
 				},
 			},
 		},
 	}
+}
+
+// eventInsertRequest extends visitInsertRequest with event specific fields
+// (Category, Action, Label and Value).
+func eventInsertRequest(v *Visit, now time.Time) *bigquery.TableDataInsertAllRequest {
+	req := visitInsertRequest(v, now)
+	for _, row := range req.Rows {
+		row.Json["Category"] = v.Category
+		row.Json["Action"] = v.Action
+		row.Json["Label"] = v.Label
+		row.Json["Value"] = v.Value
+	}
+	return req
+}
+
+func StoreVisitInBigQuery(c context.Context, v *Visit) error {
+	common.Info(">>>> StoreVisitInBigQuery")
+	common.Debug("Dataset=%s", visitsDataset)
+
+	// build the streaming request with a unique insertId
+	req := visitInsertRequest(v, time.Now())
 
 	tableName := time.Now().Format("20060102")
 	common.Debug("Table=%s", tableName)
@@ -63,48 +89,8 @@ func StoreEventInBigQuery(c context.Context, v *Visit) error {
 	common.Info(">>>> StoreEventInBigQuery")
 	common.Debug("Dataset=%s", eventsDataset)
 
-	insertId := strconv.FormatInt(time.Now().UnixNano(), 10) + "-" + v.Cookie
-
-	req := &bigquery.TableDataInsertAllRequest{
-		Kind: "bigquery#tableDataInsertAllRequest",
-		Rows: []*bigquery.TableDataInsertAllRequestRows{
-			{
-				InsertId: insertId,
-				Json: map[string]bigquery.JsonValue{
-					"Cookie":         v.Cookie,
-					"Session":        v.Session,
-					"URI":            v.URI,
-					"Referer":        v.Referer,
-					"Time":           v.Time,
-					"Host":           v.Host,
-					"RemoteAddr":     v.RemoteAddr,
-					"InstanceId":     v.InstanceId,
-					"VersionId":      v.VersionId,
-					"Scheme":         v.Scheme,
-					"Country":        v.Country,
-					"Region":         v.Region,
-					"City":           v.City,
-					"Lat":            v.Lat,
-					"Lon":            v.Lon,
-					"AcceptLanguage": v.AcceptLanguage,
-					"UserAgent":      v.UserAgent,
-					"IsMobile":       v.IsMobile,
-					"IsBot":          v.IsBot,
-					"MozillaVersion": v.MozillaVersion,
-					"Platform":       v.Platform,
-					"OS":             v.OS,
-					"EngineName":     v.EngineName,
-					"EngineVersion":  v.EngineVersion,
-					"BrowserName":    v.BrowserName,
-					"BrowserVersion": v.BrowserVersion,
-					"Category":       v.Category,
-					"Action":         v.Action,
-					"Label":          v.Label,
-					"Value":          v.Value,
-				},
-			},
-		},
-	}
+	// build the streaming request including event specific fields
+	req := eventInsertRequest(v, time.Now())
 
 	tableName := time.Now().Format("20060102")
 	common.Debug("Table=%s", tableName)

--- a/track/bigquery_store_test.go
+++ b/track/bigquery_store_test.go
@@ -1,0 +1,84 @@
+package track
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	bigquery "google.golang.org/api/bigquery/v2"
+)
+
+func TestVisitInsertRequest(t *testing.T) {
+	now := time.Unix(0, 123456789)
+	visit := &Visit{
+		Cookie:         "c",
+		Session:        "s",
+		URI:            "/foo",
+		Referer:        "http://example.com",
+		Time:           time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC),
+		Host:           "example.com",
+		RemoteAddr:     "192.168.0.1",
+		InstanceId:     "iid",
+		VersionId:      "v1",
+		Scheme:         "https",
+		Country:        "US",
+		Region:         "CA",
+		City:           "SF",
+		Lat:            1.2,
+		Lon:            3.4,
+		AcceptLanguage: "en-US",
+		UserAgent:      "agent",
+		IsMobile:       false,
+		IsBot:          false,
+		MozillaVersion: "5.0",
+		Platform:       "linux",
+		OS:             "Linux",
+		EngineName:     "webkit",
+		EngineVersion:  "1",
+		BrowserName:    "chrome",
+		BrowserVersion: "100",
+	}
+
+	got := visitInsertRequest(visit, now)
+
+	want := &bigquery.TableDataInsertAllRequest{
+		Kind: "bigquery#tableDataInsertAllRequest",
+		Rows: []*bigquery.TableDataInsertAllRequestRows{
+			{
+				InsertId: "123456789-c",
+				Json: map[string]bigquery.JsonValue{
+					"Cookie":         "c",
+					"Session":        "s",
+					"URI":            "/foo",
+					"Referer":        "http://example.com",
+					"Time":           visit.Time,
+					"Host":           "example.com",
+					"RemoteAddr":     "192.168.0.1",
+					"InstanceId":     "iid",
+					"VersionId":      "v1",
+					"Scheme":         "https",
+					"Country":        "US",
+					"Region":         "CA",
+					"City":           "SF",
+					"Lat":            1.2,
+					"Lon":            3.4,
+					"AcceptLanguage": "en-US",
+					"UserAgent":      "agent",
+					"IsMobile":       false,
+					"IsBot":          false,
+					"MozillaVersion": "5.0",
+					"Platform":       "linux",
+					"OS":             "Linux",
+					"EngineName":     "webkit",
+					"EngineVersion":  "1",
+					"BrowserName":    "chrome",
+					"BrowserVersion": "100",
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("visitInsertRequest mismatch\n got %#v\nwant %#v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- document BigQuery visit/event storage
- explain insertId creation and field mapping
- refactor store helpers and add unit test for visit requests

## Testing
- `go test ./...` *(fails: Forbidden errors while downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_6842730f169c83258891a0337905d24f