### PR TITLE
Add retry docs and tests for BigQuery inserts

### DIFF
--- a/track/bigquery_helpers.go
+++ b/track/bigquery_helpers.go
@@ -1,5 +1,10 @@
 package track
 
+// This file contains helper functions used to stream data to BigQuery while
+// automatically creating tables that may not yet exist. The core logic retries
+// the insert once after attempting to create the table when BigQuery returns a
+// "not found" error.
+
 import (
 	"github.com/patdeg/common"
 	"github.com/patdeg/common/gcp"
@@ -9,12 +14,21 @@ import (
 	"google.golang.org/api/googleapi"
 )
 
-// insertWithTableCreation streams data to BigQuery and creates the table if it doesn't exist.
+// streamDataFn is the function used to stream rows into BigQuery. It is a
+// variable so tests can replace it with a stub implementation.
+var streamDataFn = gcp.StreamDataInBigquery
+
+// insertWithTableCreation streams rows into BigQuery. If the initial insert
+// fails with a 404 "table not found" error, it will create the table using the
+// provided callback and retry the insert once.
 func insertWithTableCreation(c context.Context, projectID, datasetID, tableID string, req *bigquery.TableDataInsertAllRequest, createTable func(context.Context, string) error) error {
 	common.Debug("insertWithTableCreation dataset=%s table=%s", datasetID, tableID)
-	err := gcp.StreamDataInBigquery(c, projectID, datasetID, tableID, req)
+	err := streamDataFn(c, projectID, datasetID, tableID, req)
 	if err != nil {
 		common.Error("Error while streaming data to BigQuery: %v", err)
+		// gerr is of type *googleapi.Error when the BigQuery API returns
+		// a structured error. We specifically look for HTTP 404 to know
+		// the table does not exist.
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			common.Debug("BigQuery returned 404, attempting to create dataset/table")
 			common.Info("BigQuery table %s not found, creating table and retrying", tableID)
@@ -22,7 +36,8 @@ func insertWithTableCreation(c context.Context, projectID, datasetID, tableID st
 				common.Error("Error creating table %s: %v", tableID, err2)
 				return err2
 			}
-			if err3 := gcp.StreamDataInBigquery(c, projectID, datasetID, tableID, req); err3 != nil {
+			// Retry the insert after creating the table.
+			if err3 := streamDataFn(c, projectID, datasetID, tableID, req); err3 != nil {
 				common.Error("Error streaming to BigQuery after creating table: %v", err3)
 				return err3
 			}

--- a/track/bigquery_helpers_test.go
+++ b/track/bigquery_helpers_test.go
@@ -1,0 +1,98 @@
+package track
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	bigquery "google.golang.org/api/bigquery/v2"
+	"google.golang.org/api/googleapi"
+)
+
+// stubStreamer simulates StreamDataInBigquery behaviour.
+type stubStreamer struct {
+	errs  []error
+	calls int
+}
+
+func (s *stubStreamer) Stream(c context.Context, projectID, datasetID, tableID string, req *bigquery.TableDataInsertAllRequest) error {
+	if s.calls >= len(s.errs) {
+		s.calls++
+		return nil
+	}
+	err := s.errs[s.calls]
+	s.calls++
+	return err
+}
+
+// stubCreator records invocations of table creation.
+type stubCreator struct {
+	err   error
+	calls int
+}
+
+func (s *stubCreator) Create(ctx context.Context, table string) error {
+	s.calls++
+	return s.err
+}
+
+func TestInsertWithTableCreationSuccess(t *testing.T) {
+	streamer := &stubStreamer{errs: []error{nil}}
+	creator := &stubCreator{}
+	old := streamDataFn
+	streamDataFn = streamer.Stream
+	defer func() { streamDataFn = old }()
+
+	req := &bigquery.TableDataInsertAllRequest{}
+	err := insertWithTableCreation(context.Background(), "p", "d", "t", req, creator.Create)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if streamer.calls != 1 {
+		t.Errorf("streamer called %d times, want 1", streamer.calls)
+	}
+	if creator.calls != 0 {
+		t.Errorf("creator called %d times, want 0", creator.calls)
+	}
+}
+
+func TestInsertWithTableCreationTableMissing(t *testing.T) {
+	gerr := &googleapi.Error{Code: 404}
+	streamer := &stubStreamer{errs: []error{gerr, nil}}
+	creator := &stubCreator{}
+	old := streamDataFn
+	streamDataFn = streamer.Stream
+	defer func() { streamDataFn = old }()
+
+	req := &bigquery.TableDataInsertAllRequest{}
+	err := insertWithTableCreation(context.Background(), "p", "d", "t", req, creator.Create)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if streamer.calls != 2 {
+		t.Errorf("streamer called %d times, want 2", streamer.calls)
+	}
+	if creator.calls != 1 {
+		t.Errorf("creator called %d times, want 1", creator.calls)
+	}
+}
+
+func TestInsertWithTableCreationOtherError(t *testing.T) {
+	streamer := &stubStreamer{errs: []error{errors.New("bad")}}
+	creator := &stubCreator{}
+	old := streamDataFn
+	streamDataFn = streamer.Stream
+	defer func() { streamDataFn = old }()
+
+	req := &bigquery.TableDataInsertAllRequest{}
+	err := insertWithTableCreation(context.Background(), "p", "d", "t", req, creator.Create)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if streamer.calls != 1 {
+		t.Errorf("streamer called %d times, want 1", streamer.calls)
+	}
+	if creator.calls != 0 {
+		t.Errorf("creator called %d times, want 0", creator.calls)
+	}
+}


### PR DESCRIPTION
## Summary
- document retry behavior in bigquery helpers
- allow stubbing the BigQuery insert function
- add unit tests for success, missing table and other errors

## Testing
- `go test ./...` *(fails: module download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842730e9f20832598bca1f4c2a63c92