### PR TITLE
Add package docs and clarify getEnv

### DIFF
--- a/auth/doc.go
+++ b/auth/doc.go
@@ -1,0 +1,3 @@
+// Package auth handles Google OAuth login, sets user cookies and records
+// login events. It relies on helpers from the common and track packages.
+package auth

--- a/track/config.go
+++ b/track/config.go
@@ -3,7 +3,13 @@ package track
 
 import "os"
 
-// getEnv returns the value of the environment variable or a default.
+// getEnv returns the value of the environment variable or the provided
+// default when the variable is unset. For example:
+//
+//	port := getEnv("PORT", "8080")
+//
+// will read the PORT environment variable and fall back to "8080" when it is
+// not present.
 func getEnv(key, defaultVal string) string {
 	if v := os.Getenv(key); v != "" {
 		return v


### PR DESCRIPTION
## Summary
- add package documentation for `auth`
- document usage of `getEnv`

## Testing
- `go test ./...` *(fails: unable to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_6842730c39fc8325ae4877f3e4ba5232