### PR TITLE
Improve datastore user comments and tests

### DIFF
--- a/gcp/user.go
+++ b/gcp/user.go
@@ -1,3 +1,5 @@
+// Package gcp contains helpers backed by Google Cloud services. This file
+// implements datastore-backed storage of authenticated users and their roles.
 package gcp
 
 import (
@@ -8,14 +10,17 @@ import (
 )
 
 // User represents an authenticated user.
+// User represents an authenticated user stored in the datastore.
 type User struct {
-	Email   string
-	Role    string
-	Created time.Time
+	Email   string    // unique user identifier and datastore key
+	Role    string    // current user role, e.g. "admin" or "organizer"
+	Created time.Time // timestamp when the entity was first stored
 }
 
-// EnsureUserExists checks if a User entity with the given email exists. If not,
-// it is created with the provided role.
+// EnsureUserExists retrieves a user from the datastore by email. If the user
+// does not exist a new entity is created with the provided role. If the user
+// exists but the role differs, the stored role is updated. The resulting user
+// entity is returned.
 func EnsureUserExists(c context.Context, email, role string) (*User, error) {
 	key := datastore.NewKey(c, "User", email, 0, nil)
 	var u User
@@ -39,7 +44,8 @@ func EnsureUserExists(c context.Context, email, role string) (*User, error) {
 	return &u, nil
 }
 
-// GetUserRole fetches the role for the given user email.
+// GetUserRole fetches and returns the role for the user with the given email.
+// It returns datastore.ErrNoSuchEntity if the user is not found.
 func GetUserRole(c context.Context, email string) (string, error) {
 	key := datastore.NewKey(c, "User", email, 0, nil)
 	var u User

--- a/gcp/user_test.go
+++ b/gcp/user_test.go
@@ -1,11 +1,15 @@
 package gcp
 
 import (
+	"context"
 	"testing"
 
 	"google.golang.org/appengine/v2/aetest"
+	"google.golang.org/appengine/v2/datastore"
 )
 
+// TestEnsureUserExistsUpdatesRole verifies that calling EnsureUserExists on an
+// existing user updates the stored role.
 func TestEnsureUserExistsUpdatesRole(t *testing.T) {
 	ctx, done, err := aetest.NewContext()
 	if err != nil {
@@ -30,5 +34,56 @@ func TestEnsureUserExistsUpdatesRole(t *testing.T) {
 	}
 	if role != "admin" {
 		t.Errorf("role not updated, got %q", role)
+	}
+}
+
+// TestEnsureUserExistsCreatesUser ensures a new user entity is created with the
+// provided role when none exists.
+func TestEnsureUserExistsCreatesUser(t *testing.T) {
+	ctx, done, err := aetest.NewContext()
+	if err != nil {
+		t.Skipf("aetest not available: %v", err)
+		return
+	}
+	defer done()
+
+	email := "new@example.com"
+	if _, err := EnsureUserExists(ctx, email, "member"); err != nil {
+		t.Fatalf("EnsureUserExists: %v", err)
+	}
+	role, err := GetUserRole(ctx, email)
+	if err != nil {
+		t.Fatalf("GetUserRole: %v", err)
+	}
+	if role != "member" {
+		t.Errorf("got role %q, want member", role)
+	}
+}
+
+// TestGetUserRoleNotFound verifies that requesting the role of a nonexistent
+// user returns datastore.ErrNoSuchEntity.
+func TestGetUserRoleNotFound(t *testing.T) {
+	ctx, done, err := aetest.NewContext()
+	if err != nil {
+		t.Skipf("aetest not available: %v", err)
+		return
+	}
+	defer done()
+
+	_, err = GetUserRole(ctx, "missing@example.com")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err != datastore.ErrNoSuchEntity {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestEnsureUserExistsBadContext confirms an error is returned when the
+// datastore service is unavailable.
+func TestEnsureUserExistsBadContext(t *testing.T) {
+	// Use a background context without the aetest datastore service.
+	if _, err := EnsureUserExists(context.Background(), "bad@example.com", "admin"); err == nil {
+		t.Fatal("expected error with background context")
 	}
 }


### PR DESCRIPTION
## Summary
- document datastore-backed user storage
- add field and function comments in `gcp/user.go`
- expand user tests for creation and error handling

## Testing
- `go test ./...` *(fails: Forbidden downloading google.golang.org/api)*

------
https://chatgpt.com/codex/tasks/task_e_68427309ebe48325b0ba5140fa0f69ff