### PR TITLE
Add docs for App Engine version helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,11 @@ The packages read several configuration values from environment variables:
 
 If a variable is unset, sensible defaults defined in the code will be used.
 
+## App Engine Version
+
+The `gcp` package includes a `Version` helper that fetches the App Engine
+version ID from a request context. The function stores the major part of the
+version string in the exported `common.VERSION` variable and returns it. Call
+this helper during initialization so the application can log or act on the
+deployed version via `common.VERSION`.
+

--- a/gcp/appengine.go
+++ b/gcp/appengine.go
@@ -7,6 +7,10 @@ import (
 	appengine "google.golang.org/appengine/v2"
 )
 
+// Version retrieves the App Engine version ID from context and stores the
+// major component in the exported `common.VERSION` variable. This helper should
+// be called once during initialization so callers can read `common.VERSION`
+// throughout the application.
 func Version(c context.Context) string {
 	version := appengine.VersionID(c)
 	array := strings.Split(version, ".")


### PR DESCRIPTION
## Summary
- document the gcp Version helper in README
- explain how it sets `common.VERSION`
- add function comments describing how callers should use `Version`

## Testing
- `go test ./...` *(fails: access denied for downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_684273066f188325974ecd6142a72839