### PR TITLE
Improve spam detection docs and redirect validation

### DIFF
--- a/track/adwords.go
+++ b/track/adwords.go
@@ -283,6 +283,11 @@ func AdWordsTrackingHandler(w http.ResponseWriter, r *http.Request) {
 
 	redirectUrl := r.FormValue("url")
 	common.Debug("Redirect URL: %v", redirectUrl)
+	if !common.IsValidHTTPURL(redirectUrl) {
+		common.Error("Invalid redirect URL: %v", redirectUrl)
+		http.Error(w, "Invalid redirect URL", http.StatusBadRequest)
+		return
+	}
 
 	ua := user_agent.New(r.Header.Get("User-Agent"))
 	engineName, engineversion := ua.Engine()

--- a/track/handlers.go
+++ b/track/handlers.go
@@ -121,6 +121,9 @@ func ClickHandler(w http.ResponseWriter, r *http.Request) {
 	url := r.FormValue("url")
 	if url == "" {
 		url = "http://www.mygotome.com"
+	} else if !common.IsValidHTTPURL(url) {
+		common.Error("Invalid redirect URL: %v", url)
+		url = "http://www.mygotome.com"
 	}
 	common.Info("Redirect to %v", url)
 	http.Redirect(w, r, url, http.StatusFound)


### PR DESCRIPTION
## Summary
- document anti-spam, bot detection and HTML template helpers
- explain heuristics in IsHacker/IsMobile/IsBot/IsSpam/IsCrawler
- keep spammer/bot lists in dedicated variables
- validate AdWords and click redirect URLs

## Testing
- `go test ./...` *(fails: access denied to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_68427305ded4832582daa73cca1cc398