### PR TITLE
Switch to AES‑GCM encryption

### DIFF
--- a/crypt_test.go
+++ b/crypt_test.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"context"
+	"testing"
+)
+
+func TestEncryptDecrypt(t *testing.T) {
+	msg := "hello world"
+	key := "secret"
+	enc := Encrypt(context.Background(), key, msg)
+	if enc == "" {
+		t.Fatal("empty ciphertext")
+	}
+	dec := Decrypt(context.Background(), key, enc)
+	if dec != msg {
+		t.Fatalf("Decrypt = %q, want %q", dec, msg)
+	}
+}
+
+func TestDecryptWrongKey(t *testing.T) {
+	msg := "secret data"
+	enc := Encrypt(context.Background(), "k1", msg)
+	dec := Decrypt(context.Background(), "k2", enc)
+	if dec != "" {
+		t.Fatalf("expected empty result with wrong key, got %q", dec)
+	}
+}
+
+func TestDecryptInvalidHex(t *testing.T) {
+	dec := Decrypt(context.Background(), "k", "invalid")
+	if dec != "" {
+		t.Fatalf("expected empty result for bad input, got %q", dec)
+	}
+}


### PR DESCRIPTION
## Summary
- document cryptographic helpers
- replace insecure AES-CFB encryption with AES-GCM
- prepend nonce to ciphertext and parse it back in `Decrypt`
- add tests for encryption/decryption and error handling

## Testing
- `go test ./...` *(fails: Forbidden when fetching google.golang.org/api)*

------
https://chatgpt.com/codex/tasks/task_e_684272feffb88325a5ed3d8e36a45e1b