### PR TITLE
Add Apache license header to Go files

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package auth implements a minimal Google OAuth workflow used by the
 // other packages in this repository. Users are redirected to Google for
 // authentication and, on success, returned to /goog_callback where their

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package auth
 
 import (

--- a/auth/doc.go
+++ b/auth/doc.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package auth handles Google OAuth login, sets user cookies and records
 // login events. It relies on helpers from the common and track packages.
 package auth

--- a/common.go
+++ b/common.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package common provides helper utilities shared across the repository. The
 // helpers include logging routines, conversion helpers and small web utilities.
 //

--- a/convert.go
+++ b/convert.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package common contains small conversion helpers used throughout the
 // repository. The functions here convert between strings, numbers and other
 // primitive types and provide helpers for formatting values.

--- a/convert_test.go
+++ b/convert_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package common contains small helper routines used across different
 // packages. The tests in this file verify the behaviour of the conversion
 // utilities implemented in convert.go.

--- a/cookie.go
+++ b/cookie.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package common provides shared helpers used across the application.
 // It includes utilities for reading and writing HTTP requests and responses
 // such as the JSON/XML helpers found in interfaces.go.

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package common contains tests for cookie helpers.
 package common
 

--- a/crypt.go
+++ b/crypt.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 // This file provides small cryptographic helpers used across the repository.

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 import (

--- a/debug.go
+++ b/debug.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package common provides assorted helpers. This file contains debugging
 // utilities used to dump HTTP requests, responses and cookies when
 // troubleshooting issues during development.

--- a/examples/appengine/main.go
+++ b/examples/appengine/main.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package main provides a minimal example server showing how to use the
 // authentication helpers from the common repository. It defines a simple
 // greeting handler and wires up the OAuth login and callback handlers from the

--- a/file.go
+++ b/file.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 import (

--- a/file_test.go
+++ b/file_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 import (

--- a/ga/ga.go
+++ b/ga/ga.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package ga provides helpers for sending hits to Google Analytics using the
 // Measurement Protocol. The package exposes helper types and functions to
 // collect information from an HTTP request and transmit it to the GA endpoint.

--- a/gcp/appengine.go
+++ b/gcp/appengine.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gcp
 
 import (

--- a/gcp/bigquery.go
+++ b/gcp/bigquery.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package gcp provides Google Cloud helpers for mygoto.me service.
 //
 // This file contains helpers for interacting with BigQuery. It includes

--- a/gcp/datastore.go
+++ b/gcp/datastore.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package gcp provides Google Cloud helpers. This file defines helpers for
 // retrieving results from Cloud Datastore queries.
 package gcp

--- a/gcp/memcache.go
+++ b/gcp/memcache.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gcp
 
 // This file provides small wrappers around App Engine's memcache library.

--- a/gcp/user.go
+++ b/gcp/user.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package gcp contains helpers backed by Google Cloud services. This file
 // implements datastore-backed storage of authenticated users and their roles.
 package gcp

--- a/gcp/user_test.go
+++ b/gcp/user_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gcp
 
 import (

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package common contains request and response helpers for JSON and XML.
 // It exposes utilities like GetBody, WriteJSON and UnmarshalResponse for
 // working with HTTP handlers.

--- a/logging.go
+++ b/logging.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // logging.go provides a tiny wrapper around the standard log package.
 // The helpers here format messages consistently and funnel all logs
 // through log.Printf. Debug obeys the global ISDEBUG variable so it

--- a/slice.go
+++ b/slice.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package common provides shared utilities used throughout the repository.
 //
 // This file contains simple helpers for working with slices. They are

--- a/slice_test.go
+++ b/slice_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 import "testing"

--- a/track/adwords.go
+++ b/track/adwords.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package track contains analytics helpers.
 //
 // This file implements AdWords click tracking. The handler stores the

--- a/track/adwords_test.go
+++ b/track/adwords_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package track
 
 import (

--- a/track/base.go
+++ b/track/base.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package track defines helpers used for pixel tracking and BigQuery storage.
 //
 // Dataset variables hold the BigQuery project and dataset names for visits,

--- a/track/bigquery_helpers.go
+++ b/track/bigquery_helpers.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package track
 
 // This file contains helper functions used to stream data to BigQuery while

--- a/track/bigquery_helpers_test.go
+++ b/track/bigquery_helpers_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package track
 
 import (

--- a/track/bigquery_store.go
+++ b/track/bigquery_store.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package track
 
 // This file contains helpers to persist Visit and Event records in BigQuery.

--- a/track/bigquery_store_test.go
+++ b/track/bigquery_store_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package track
 
 import (

--- a/track/bigquery_tables.go
+++ b/track/bigquery_tables.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package track
 
 import (

--- a/track/config.go
+++ b/track/config.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package track contains analytics helpers for recording visits and events.
 package track
 

--- a/track/handlers.go
+++ b/track/handlers.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package track provides helpers for analytics collection. This file contains
 // HTTP handlers used by the tracking service. Handlers are provided to create
 // daily BigQuery tables, serve the tracking pixel and record outbound clicks.

--- a/track/tracker.go
+++ b/track/tracker.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package track
 
 // This file contains the core tracking logic used by the handlers in this

--- a/track/types.go
+++ b/track/types.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package track contains analytics helpers for recording visits and events.
 // This file defines the structures used to store visit details and robot hits
 // in Datastore and BigQuery.

--- a/url.go
+++ b/url.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 import "net/url"

--- a/url_test.go
+++ b/url_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package common contains tests for URL helpers.
 package common
 

--- a/web.go
+++ b/web.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Patrick Deglon
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 // This file provides helper functions used across HTTP handlers to detect


### PR DESCRIPTION
## Summary
- add Apache 2.0 license header to all Go source files

## Testing
- `go test ./...` *(fails: `Forbidden`)*

------
https://chatgpt.com/codex/tasks/task_e_68427aa14a148325bb4f0f421b30be2e