### PR TITLE
Fix compile issues and tests

### DIFF
--- a/ga/ga.go
+++ b/ga/ga.go
@@ -36,6 +36,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/patdeg/common"
 	"golang.org/x/net/context"
 	"google.golang.org/appengine/v2/mail"
 	"google.golang.org/appengine/v2/urlfetch"
@@ -245,7 +246,7 @@ func GetEvent(r *http.Request) GAEvent {
 		}
 	}
 	if guid == "" {
-		guid = Encrypt(r.Context(), "", MD5(r.RemoteAddr+r.Header.Get("User-Agent")))
+		guid = common.Encrypt(r.Context(), "", common.MD5(r.RemoteAddr+r.Header.Get("User-Agent")))
 	}
 
 	query := ""
@@ -299,20 +300,20 @@ func TrackGAPage(c context.Context, PropertyID string, event GAEvent) {
 	v := setEvent("pageview", event)
 	v.Set("tid", PropertyID)
 	payload_data := v.Encode()
-	Info("GA: Calling %v with %v", endpointUrl, payload_data)
+	common.Info("GA: Calling %v with %v", endpointUrl, payload_data)
 
 	req, err := http.NewRequest("POST", endpointUrl, bytes.NewBufferString(payload_data))
 	if err != nil {
-		Error("Error while tracking Google Analytics: %v", err)
+		common.Error("Error while tracking Google Analytics: %v", err)
 		return
 	}
 	resp, err := urlfetch.Client(c).Do(req)
 	if err != nil {
-		Error("Error while tracking Google Analytics: %v", err)
+		common.Error("Error while tracking Google Analytics: %v", err)
 		return
 	}
 
-	Debug("GA status code %v", resp.StatusCode)
+	common.Debug("GA status code %v", resp.StatusCode)
 }
 
 // TrackGAEvent sends an event hit to Google Analytics using the supplied
@@ -329,20 +330,20 @@ func TrackGAEvent(c context.Context, PropertyID string, event GAEvent) {
 	v := setEvent("event", event)
 	v.Set("tid", PropertyID)
 	payload_data := v.Encode()
-	Info("GA: Calling %v with %v", endpointUrl, payload_data)
+	common.Info("GA: Calling %v with %v", endpointUrl, payload_data)
 
 	req, err := http.NewRequest("POST", endpointUrl, bytes.NewBufferString(payload_data))
 	if err != nil {
-		Error("Error while tracking Google Analytics: %v", err)
+		common.Error("Error while tracking Google Analytics: %v", err)
 		return
 	}
 	resp, err := urlfetch.Client(c).Do(req)
 	if err != nil {
-		Error("Error while tracking Google Analytics: %v", err)
+		common.Error("Error while tracking Google Analytics: %v", err)
 		return
 	}
 
-	Debug("GA status code %v", resp.StatusCode)
+	common.Debug("GA status code %v", resp.StatusCode)
 }
 
 // GATrackServeError renders an HTTP error response and records the failure as a
@@ -352,7 +353,7 @@ func GATrackServeError(w http.ResponseWriter, r *http.Request, PropertyID string
 	errorTitle, errorMessage string, err error, code int, isFatal bool, AppEngineEmail string) {
 	c := r.Context()
 	if err != nil {
-		Error("%v: %v", errorMessage, err.Error())
+		common.Error("%v: %v", errorMessage, err.Error())
 	}
 	event := GetEvent(r)
 	event.ExceptionDescription = errorMessage
@@ -368,7 +369,7 @@ func GATrackServeError(w http.ResponseWriter, r *http.Request, PropertyID string
 			Body:    fmt.Sprintf(`There was a fatal error on %v at %v: %v`, r.Host, time.Now(), errorMessage),
 		}
 		if err := mail.Send(c, msg); err != nil {
-			Error("Couldn't send error email: %v", err)
+			common.Error("Couldn't send error email: %v", err)
 		}
 	} else {
 		event.IsExceptionFatal = ""

--- a/gcp/helpers.go
+++ b/gcp/helpers.go
@@ -1,0 +1,36 @@
+package gcp
+
+import (
+	"bytes"
+	"log"
+)
+
+// VERSION stores the deployed application version retrieved from App Engine.
+// It is set by the Version helper in appengine.go.
+var VERSION string
+
+// Debug writes a formatted debug message. This is a lightweight replacement
+// for the helpers in the parent package to avoid an import cycle.
+func Debug(format string, v ...interface{}) {
+	log.Printf(format+"\n", v...)
+}
+
+// Info writes a formatted informational message.
+func Info(format string, v ...interface{}) {
+	log.Printf(format+"\n", v...)
+}
+
+// Error writes a formatted error message prefixed with "ERROR:".
+func Error(format string, v ...interface{}) {
+	log.Printf("ERROR: "+format+"\n", v...)
+}
+
+// b2s converts a byte slice possibly containing a null terminator into a string.
+// It mirrors common.B2S but is duplicated here to avoid a package dependency.
+func B2S(b []byte) string {
+	n := bytes.Index(b, []byte{0})
+	if n > 0 {
+		return string(b[:n])
+	}
+	return string(b)
+}

--- a/gcp/user.go
+++ b/gcp/user.go
@@ -17,9 +17,11 @@
 package gcp
 
 import (
+	"errors"
 	"time"
 
 	"golang.org/x/net/context"
+	appengine "google.golang.org/appengine/v2"
 	"google.golang.org/appengine/v2/datastore"
 )
 
@@ -36,6 +38,9 @@ type User struct {
 // exists but the role differs, the stored role is updated. The resulting user
 // entity is returned.
 func EnsureUserExists(c context.Context, email, role string) (*User, error) {
+	if !appengine.IsAppEngine() && !appengine.IsDevAppServer() {
+		return nil, errors.New("datastore unavailable")
+	}
 	key := datastore.NewKey(c, "User", email, 0, nil)
 	var u User
 	err := datastore.Get(c, key, &u)
@@ -61,6 +66,9 @@ func EnsureUserExists(c context.Context, email, role string) (*User, error) {
 // GetUserRole fetches and returns the role for the user with the given email.
 // It returns datastore.ErrNoSuchEntity if the user is not found.
 func GetUserRole(c context.Context, email string) (string, error) {
+	if !appengine.IsAppEngine() && !appengine.IsDevAppServer() {
+		return "", errors.New("datastore unavailable")
+	}
 	key := datastore.NewKey(c, "User", email, 0, nil)
 	var u User
 	if err := datastore.Get(c, key, &u); err != nil {

--- a/track/bigquery_helpers_test.go
+++ b/track/bigquery_helpers_test.go
@@ -28,7 +28,7 @@ import (
 func TestInsertWithTableCreation404(t *testing.T) {
 	ctx := context.Background()
 	called := 0
-	streamData = func(context.Context, string, string, string, *bigquery.TableDataInsertAllRequest) error {
+	streamDataFn = func(context.Context, string, string, string, *bigquery.TableDataInsertAllRequest) error {
 		called++
 		if called == 1 {
 			return &googleapi.Error{Code: 404}
@@ -52,7 +52,7 @@ func TestInsertWithTableCreation404(t *testing.T) {
 // TestInsertWithTableCreationError ensures non-404 errors are returned.
 func TestInsertWithTableCreationError(t *testing.T) {
 	ctx := context.Background()
-	streamData = func(context.Context, string, string, string, *bigquery.TableDataInsertAllRequest) error {
+	streamDataFn = func(context.Context, string, string, string, *bigquery.TableDataInsertAllRequest) error {
 		return errors.New("fail")
 	}
 	create := func(context.Context, string) error { t.Error("createTable should not be called"); return nil }
@@ -65,7 +65,7 @@ func TestInsertWithTableCreationError(t *testing.T) {
 func TestInsertWithTableCreationCreateError(t *testing.T) {
 	ctx := context.Background()
 	called := 0
-	streamData = func(context.Context, string, string, string, *bigquery.TableDataInsertAllRequest) error {
+	streamDataFn = func(context.Context, string, string, string, *bigquery.TableDataInsertAllRequest) error {
 		called++
 		return &googleapi.Error{Code: 404}
 	}
@@ -75,6 +75,8 @@ func TestInsertWithTableCreationCreateError(t *testing.T) {
 	}
 	if called != 1 {
 		t.Errorf("streamData called %d times, want 1", called)
+	}
+}
 
 // stubStreamer simulates StreamDataInBigquery behaviour.
 type stubStreamer struct {

--- a/track/bigquery_store.go
+++ b/track/bigquery_store.go
@@ -33,11 +33,8 @@ import (
 // The insertId combines the current timestamp in nanoseconds with the visitor
 // cookie to ensure uniqueness and allow de-duplication on retries.
 // Each Visit field is mapped directly to a column in BigQuery.
-func StoreVisitInBigQuery(c context.Context, v *Visit) error {
-	common.Info(">>>> StoreVisitInBigQuery")
-	common.Debug("Dataset=%s", visitsDataset)
-
-	insertId := strconv.FormatInt(time.Now().UnixNano(), 10) + "-" + v.Cookie
+func visitInsertRequest(v *Visit, now time.Time) *bigquery.TableDataInsertAllRequest {
+	insertId := strconv.FormatInt(now.UnixNano(), 10) + "-" + v.Cookie
 
 	req := &bigquery.TableDataInsertAllRequest{
 		Kind: "bigquery#tableDataInsertAllRequest",
@@ -75,6 +72,8 @@ func StoreVisitInBigQuery(c context.Context, v *Visit) error {
 			},
 		},
 	}
+
+	return req
 }
 
 // eventInsertRequest extends visitInsertRequest with event specific fields


### PR DESCRIPTION
## Summary
- add lightweight logging helpers in gcp package to avoid import cycle
- adjust App Engine version helper accordingly
- import `common` in GA helpers
- add checks for datastore availability in gcp user helpers
- fix broken BigQuery helpers and tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6871eae410ec832587e46b27d9e96b9d